### PR TITLE
Fix IndexError in plot_fractal_tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python

--- a/nano_star_simulation.py
+++ b/nano_star_simulation.py
@@ -143,7 +143,7 @@ def plot_fractal_tree(ax, proton, x, y, angle, length, depth):
 
     ax.plot([x, x_end], [y, y_end], 'w-')
 
-    children = [p for p in proton_lineage if p.lineage[-1] == proton.id]
+    children = [p for p in proton_lineage if p.lineage and p.lineage[-1] == proton.id]
     if len(children) == 2:
         plot_fractal_tree(ax, children[0], x_end, y_end, angle - 30, length * 0.7, depth - 1)
         plot_fractal_tree(ax, children[1], x_end, y_end, angle + 30, length * 0.7, depth - 1)

--- a/test_plotting.py
+++ b/test_plotting.py
@@ -4,6 +4,9 @@ from nano_star_simulation import plot_fractal_tree, Proton, proton_lineage
 
 class TestPlotting(unittest.TestCase):
 
+    def tearDown(self):
+        proton_lineage.clear()
+
     def test_plot_fractal_tree_index_error(self):
         """
         Tests that the plot_fractal_tree function does not raise an IndexError
@@ -12,11 +15,9 @@ class TestPlotting(unittest.TestCase):
         fig, ax = plt.subplots()
         initial_proton = Proton("P0", [])
         proton_lineage.append(initial_proton)
-
-        try:
-            plot_fractal_tree(ax, initial_proton, 0, 0, 90, 1, 1)
-        except IndexError:
-            self.fail("plot_fractal_tree() raised IndexError unexpectedly!")
+        
+        # This will fail the test automatically if IndexError is raised
+        plot_fractal_tree(ax, initial_proton, 0, 0, 90, 1, 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_plotting.py
+++ b/test_plotting.py
@@ -1,0 +1,22 @@
+import unittest
+import matplotlib.pyplot as plt
+from nano_star_simulation import plot_fractal_tree, Proton, proton_lineage
+
+class TestPlotting(unittest.TestCase):
+
+    def test_plot_fractal_tree_index_error(self):
+        """
+        Tests that the plot_fractal_tree function does not raise an IndexError
+        when a proton with an empty lineage is present.
+        """
+        fig, ax = plt.subplots()
+        initial_proton = Proton("P0", [])
+        proton_lineage.append(initial_proton)
+
+        try:
+            plot_fractal_tree(ax, initial_proton, 0, 0, 90, 1, 1)
+        except IndexError:
+            self.fail("plot_fractal_tree() raised IndexError unexpectedly!")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`The` `plot_fractal_tree` function could raise an `IndexError` if a proton with an empty lineage was present in the `proton_lineage` list. This was because the list comprehension used to find children of a proton accessed `p.lineage[-1]` without first checking if `p.lineage` was empty.

The fix adds a check to ensure `p.lineage` is not empty before accessing its last element.

A new test case was added in `test_plotting.py` to specifically target this edge case and verify the fix. The test fails before the fix and passes after.