### PR TITLE
🔖 Title tests: ensure headless matplotlib backend and lineage cleanup in fractal tree test

### DIFF
--- a/test_plotting.py
+++ b/test_plotting.py
@@ -1,0 +1,30 @@
+import unittest
+import matplotlib
+matplotlib.use('Agg')  # use non-interactive backend for tests
+import matplotlib.pyplot as plt
+from nano_star_simulation import plot_fractal_tree, Proton, proton_lineage
+
+class TestPlotting(unittest.TestCase):
+
+    def test_plot_fractal_tree_index_error(self):
+        """
+        Tests that the plot_fractal_tree function does not raise an IndexError
+        when a proton with an empty lineage is present.
+        """
+        fig, ax = plt.subplots()
+        initial_proton = Proton("P0", [])
+        proton_lineage.append(initial_proton)
+
+        try:
+            plot_fractal_tree(ax, initial_proton, 0, 0, 90, 1, 1)
+        except IndexError:
+            self.fail("plot_fractal_tree() raised IndexError unexpectedly!")
+        finally:
+            # cleanup so other tests aren't affected
+            try:
+                proton_lineage.remove(initial_proton)
+            except ValueError:
+                pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…age in test
🧬 Description
This merge introduces a focused test case for plot_fractal_tree() that ensures robustness when handling protons with empty lineage. It sets the matplotlib backend to 'Agg' to support headless CI environments and includes a cleanup routine to remove the test proton from proton_lineage after execution, preventing side effects across test runs.

Key changes:

✅ Sets matplotlib.use('Agg') to avoid GUI dependency during testing

🧪 Adds TestPlotting.test_plot_fractal_tree_index_error() to verify no IndexError occurs with empty lineage

🧹 Cleans up proton_lineage after test to maintain test isolation

🔒 Ensures CI compatibility and reproducibility

This test complements the recent update to plot_fractal_tree() that guards against empty lineage traversal. Together, they reinforce the simulation’s resilience and ceremonial clarity.
